### PR TITLE
Add support for OpenSSL 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           - 2.5.8
           - 2.4.10
         gemfile:
+          - openssl_3_0
           - openssl_2_2
           - openssl_2_1
           - openssl_2_0

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+appraise "openssl_3_0" do
+  gem "openssl", "~> 3.0.0"
+end
+
 appraise "openssl_2_2" do
   gem "openssl", "~> 2.2.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     openssl-signature_algorithm (1.1.1)
-      openssl (~> 2.0)
+      openssl (> 2.0, < 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
     diff-lcs (1.3)
     ed25519 (1.2.4)
     jaro_winkler (1.5.4)
-    openssl (2.2.0)
+    openssl (3.0.0)
     parallel (1.19.1)
     parser (2.7.0.5)
       ast (~> 2.4.0)

--- a/lib/openssl/signature_algorithm/rsa.rb
+++ b/lib/openssl/signature_algorithm/rsa.rb
@@ -7,13 +7,9 @@ require "openssl/signature_algorithm/base"
 module OpenSSL
   module SignatureAlgorithm
     class RSA < Base
-      class SigningKey < Delegator
-        def __getobj__
-          @pkey
-        end
-
+      class SigningKey < DelegateClass(OpenSSL::PKey::RSA)
         def initialize(*args)
-          @pkey = OpenSSL::PKey::RSA.new(*args)
+          super(OpenSSL::PKey::RSA.new(*args))
         end
 
         def verify_key
@@ -21,17 +17,13 @@ module OpenSSL
         end
       end
 
-      class VerifyKey < Delegator
-        def __getobj__
-          @pkey
+      class VerifyKey < DelegateClass(OpenSSL::PKey::RSA)
+        class << self
+          alias_method :deserialize, :new
         end
 
         def initialize(*args)
-          @pkey = OpenSSL::PKey::RSA.new(*args)
-        end
-
-        class << self
-          alias_method :deserialize, :new
+          super(OpenSSL::PKey::RSA.new(*args))
         end
 
         def serialize

--- a/lib/openssl/signature_algorithm/rsa.rb
+++ b/lib/openssl/signature_algorithm/rsa.rb
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
-require "forwardable"
+require "delegate"
 require "openssl"
 require "openssl/signature_algorithm/base"
 
 module OpenSSL
   module SignatureAlgorithm
     class RSA < Base
-      class SigningKey
-        extend Forwardable
-
-        def_delegators :@pkey, :sign, :verify
-        def_delegators :@pkey, :public_key, :private_key, :to_pem, :to_der, :public?, :private?, :export, :to_s
-        def_delegators :@pkey, :public_encrypt, :public_decrypt, :private_encrypt, :private_decrypt
-        def_delegators :@pkey, :sign_pss, :verify_pss
-        def_delegators :@pkey, :blinding_off!, :blinding_on!
-        def_delegators :@pkey, :params, :to_text
+      class SigningKey < Delegator
+        def __getobj__
+          @pkey
+        end
 
         def initialize(*args)
-          @pkey = OpenSSL::PKey::RSA.generate(*args)
+          @pkey = OpenSSL::PKey::RSA.new(*args)
         end
 
         def verify_key
@@ -26,7 +21,15 @@ module OpenSSL
         end
       end
 
-      class VerifyKey < OpenSSL::PKey::RSA
+      class VerifyKey < Delegator
+        def __getobj__
+          @pkey
+        end
+
+        def initialize(*args)
+          @pkey = OpenSSL::PKey::RSA.new(*args)
+        end
+
         class << self
           alias_method :deserialize, :new
         end

--- a/lib/openssl/signature_algorithm/rsa.rb
+++ b/lib/openssl/signature_algorithm/rsa.rb
@@ -1,12 +1,26 @@
 # frozen_string_literal: true
 
+require "forwardable"
 require "openssl"
 require "openssl/signature_algorithm/base"
 
 module OpenSSL
   module SignatureAlgorithm
     class RSA < Base
-      class SigningKey < OpenSSL::PKey::RSA
+      class SigningKey
+        extend Forwardable
+
+        def_delegators :@pkey, :sign, :verify
+        def_delegators :@pkey, :public_key, :private_key, :to_pem, :to_der, :public?, :private?, :export, :to_s
+        def_delegators :@pkey, :public_encrypt, :public_decrypt, :private_encrypt, :private_decrypt
+        def_delegators :@pkey, :sign_pss, :verify_pss
+        def_delegators :@pkey, :blinding_off!, :blinding_on!
+        def_delegators :@pkey, :params, :to_text
+
+        def initialize(*args)
+          @pkey = OpenSSL::PKey::RSA.generate(*args)
+        end
+
         def verify_key
           VerifyKey.new(public_key.to_pem)
         end

--- a/openssl-signature_algorithm.gemspec
+++ b/openssl-signature_algorithm.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "openssl", "~> 2.0"
+  spec.add_runtime_dependency "openssl", "> 2.0", "< 3.1"
 end


### PR DESCRIPTION
Fixes #4

`ECDSA::SigningKey` and `RSA::SigningKey` are changed to wrap the OpenSSL `PKey` classes instead of inheriting them, because there seem to be no way with version 3.0.0 of the `openssl` gem to generate such PKeys without using a `.generate` factory method.