### PR TITLE
Allow for openssl gem 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     openssl-signature_algorithm (1.2.1)
-      openssl (> 2.0, < 3.1)
+      openssl (> 2.0, <= 3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/openssl-signature_algorithm.gemspec
+++ b/openssl-signature_algorithm.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "openssl", "> 2.0", "< 3.1"
+  spec.add_runtime_dependency "openssl", "> 2.0", "<= 3.1"
 end


### PR DESCRIPTION
This change is needed for openssl to work in Ruby 3.2.0 since Ruby 3.2.0 ships with the openssl 3.1 by default.