### PR TITLE
Test against `Ruby 3.3`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,6 @@ jobs:
         bundler-cache: true
     - name: Run rubocop
       run: bundle exec rubocop
-      if: ${{ matrix.ruby == '3.2' }}
+      if: ${{ matrix.ruby == '3.3' }}
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
+          - 3.3
           - 3.2
           - 3.1
           - '3.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,6 @@ jobs:
         bundler-cache: true
     - name: Run rubocop
       run: bundle exec rubocop
-      if: ${{ matrix.ruby == '3.3' }}
+      if: ${{ matrix.ruby-version == '3.3' }}
     - name: Run tests
       run: bundle exec rspec


### PR DESCRIPTION
⚠️ This PR depends on #11 ⚠️

## Summary

- Test against `Ruby 3.3`
- Test `rubocop` against `Ruby 3.3`
- Start running `rubocop` job again