### PR TITLE
Test against different OpenSSL library versions

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -1,0 +1,55 @@
+name: Install OpenSSL
+
+inputs:
+  version:
+    description: 'The version of OpenSSL to install'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore cached OpenSSL library
+      id: cache-openssl-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/openssl
+        key: openssl-${{ inputs.version }}
+
+    - name: Compile OpenSSL library
+      if: steps.cache-openssl-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p tmp/build-openssl && cd tmp/build-openssl
+        case ${{ inputs.version }} in
+        1.1.*)
+          OPENSSL_COMMIT=OpenSSL_
+          OPENSSL_COMMIT+=$(echo ${{ inputs.version  }} | sed -e 's/\./_/g')
+          git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
+          echo "Git commit: $(git rev-parse HEAD)"
+          ./Configure --prefix=$HOME/openssl --libdir=lib linux-x86_64
+          make depend && make -j4 && make install_sw
+          ;;
+        3.*)
+          OPENSSL_COMMIT=openssl-
+          OPENSSL_COMMIT+=$(echo ${{ inputs.version  }})
+          git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
+          echo "Git commit: $(git rev-parse HEAD)"
+          if [[ ${{ inputs.version }} == 3.5* ]]; then
+            ./Configure --prefix=$HOME/openssl --libdir=lib enable-fips no-tests no-legacy
+          else
+            ./Configure --prefix=$HOME/openssl --libdir=lib enable-fips no-tests
+          fi
+          make -j4 && make install_sw && make install_fips
+          ;;
+        *)
+          echo "Don't know how to build OpenSSL ${{ inputs.version }}"
+          ;;
+        esac
+
+    - name: Save OpenSSL library cache
+      if: steps.cache-openssl-restore.outputs.cache-hit != 'true'
+      id: cache-openssl-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/openssl
+        key: ${{ steps.cache-openssl-restore.outputs.cache-primary-key }}

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -38,6 +38,13 @@ runs:
       run: |
         echo "~/rubies/ruby-${{ inputs.version }}/bin" >> $GITHUB_PATH
 
+    - name: Trust system CA certificates (Ruby 2.4's bundled RubyGems lacks current roots)
+      if: inputs.version == '2.4'
+      shell: bash
+      run: |
+        echo "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
+        echo "SSL_CERT_DIR=/etc/ssl/certs" >> $GITHUB_ENV
+
     - name: Install Bundler
       shell: bash
       run: |

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -1,0 +1,82 @@
+name: Install Ruby
+
+inputs:
+  version:
+    description: 'The version of Ruby to install'
+    required: true
+  openssl-version:
+    description: 'The version of OpenSSL used'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore cached Ruby installation
+      id: cache-ruby-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/rubies/ruby-${{ inputs.version }}
+        key: ruby-${{ inputs.version }}-with-openssl-${{ inputs.openssl-version }}
+
+    - name: Install Ruby
+      if: steps.cache-ruby-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        latest_patch=$(curl -s https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ \
+           | grep -oP "ruby-${{ inputs.version }}\.\d+\.tar\.xz" \
+           | grep -oP "\d+(?=\.tar\.xz)" \
+           | sort -V | tail -n 1)
+        wget https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        tar -xJvf ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        cd ruby-${{ inputs.version }}.${latest_patch}
+        ./configure --prefix=$HOME/rubies/ruby-${{ inputs.version }} --with-openssl-dir=$HOME/openssl
+        make
+        make install
+
+    - name: Update PATH
+      shell: bash
+      run: |
+        echo "~/rubies/ruby-${{ inputs.version }}/bin" >> $GITHUB_PATH
+
+    - name: Install Bundler
+      shell: bash
+      run: |
+        case ${{ inputs.version }} in
+        2.7* | 3.*)
+          echo "Skipping Bundler installation for Ruby ${{ inputs.version }}"
+          ;;
+        2.4* | 2.5* | 2.6*)
+          gem install bundler -v '~> 2.3.0'
+          ;;
+        *)
+          echo "Don't know how to install Bundler for Ruby ${{ inputs.version }}"
+          ;;
+        esac
+
+    - name: Save Ruby installation cache
+      if: steps.cache-ruby-restore.outputs.cache-hit != 'true'
+      id: cache-ruby-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/rubies/ruby-${{ inputs.version }}
+        key: ${{ steps.cache-ruby-restore.outputs.cache-primary-key }}
+
+    - name: Cache Bundler Install
+      id: cache-bundler-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/bundler/cache
+        key: bundler-ruby-${{ inputs.version }}-${{ inputs.openssl-version }}-${{ hashFiles(env.BUNDLE_GEMFILE, 'openssl-signature_algorithm.gemspec') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        bundle config set --local path ~/bundler/cache
+        bundle install
+
+    - name: Save Bundler Install cache
+      id: cache-bundler-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/bundler/cache
+        key: ${{ steps.cache-bundler-restore.outputs.cache-primary-key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,73 +26,77 @@ jobs:
       - name: Lint code for consistent style
         run: bundle exec rubocop -f github
   test:
+    name: 'Ruby ${{ matrix.ruby-version }} | ${{ matrix.gemfile }} | OpenSSL ${{ matrix.openssl }}'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         ruby-version:
-          - 3.4
-          - 3.3
-          - 3.2
-          - 3.1
-          - '3.0'
-          - 2.7
-          - 2.6
-          - 2.5
-          - 2.4
+          - '3.4'
+          - '3.3'
+          - '3.2'
+          - '3.1'
         gemfile:
           - openssl_3_3
           - openssl_3_2
           - openssl_3_1
           - openssl_3_0
-          - openssl_2_2
-          - openssl_2_1
-        exclude:
-          - ruby-version: '2.4'
-            gemfile: openssl_3_0
-          - ruby-version: '2.5'
-            gemfile: openssl_3_0
-          - ruby-version: '2.4'
-            gemfile: openssl_3_1
-          - ruby-version: '2.5'
-            gemfile: openssl_3_1
-          - ruby-version: '2.4'
-            gemfile: openssl_3_2
-          - ruby-version: '2.5'
-            gemfile: openssl_3_2
-          - ruby-version: '2.6'
-            gemfile: openssl_3_2
-          - ruby-version: '2.4'
-            gemfile: openssl_3_3
-          - ruby-version: '2.5'
-            gemfile: openssl_3_3
-          - ruby-version: '2.6'
-            gemfile: openssl_3_3
-          - ruby-version: '3.1'
-            gemfile: openssl_2_1
-          - ruby-version: '3.1'
-            gemfile: openssl_2_2
-          - ruby-version: '3.2'
-            gemfile: openssl_2_1
-          - ruby-version: '3.2'
-            gemfile: openssl_2_2
-          - ruby-version: '3.3'
-            gemfile: openssl_2_1
-          - ruby-version: '3.3'
-            gemfile: openssl_2_2
-          - ruby-version: '3.4'
-            gemfile: openssl_2_1
-          - ruby-version: '3.4'
-            gemfile: openssl_2_2
+        openssl:
+          - '3.6.0'
+          - '3.5.4'
+          - '3.4.3'
+          - '3.3.5'
+          - '3.2.6'
+          - '3.1.8'
+          - '3.0.18'
+          - '1.1.1w'
+        include:
+          - { ruby-version: '3.4', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '3.4', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '3.3', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '3.3', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '3.2', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '3.2', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '3.1', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '3.1', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          # Legacy Rubies (<= 3.0) only build against OpenSSL 1.1.1w, since their
+          # bundled openssl extension caps at 1.1.1. Each Ruby is paired with every
+          # openssl gem version it supports.
+          - { ruby-version: '3.0', gemfile: openssl_3_3, openssl: '1.1.1w' }
+          - { ruby-version: '3.0', gemfile: openssl_3_2, openssl: '1.1.1w' }
+          - { ruby-version: '3.0', gemfile: openssl_3_1, openssl: '1.1.1w' }
+          - { ruby-version: '3.0', gemfile: openssl_3_0, openssl: '1.1.1w' }
+          - { ruby-version: '3.0', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '3.0', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '2.7', gemfile: openssl_3_3, openssl: '1.1.1w' }
+          - { ruby-version: '2.7', gemfile: openssl_3_2, openssl: '1.1.1w' }
+          - { ruby-version: '2.7', gemfile: openssl_3_1, openssl: '1.1.1w' }
+          - { ruby-version: '2.7', gemfile: openssl_3_0, openssl: '1.1.1w' }
+          - { ruby-version: '2.7', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '2.7', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '2.6', gemfile: openssl_3_1, openssl: '1.1.1w' }
+          - { ruby-version: '2.6', gemfile: openssl_3_0, openssl: '1.1.1w' }
+          - { ruby-version: '2.6', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '2.6', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '2.5', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '2.5', gemfile: openssl_2_1, openssl: '1.1.1w' }
+          - { ruby-version: '2.4', gemfile: openssl_2_2, openssl: '1.1.1w' }
+          - { ruby-version: '2.4', gemfile: openssl_2_1, openssl: '1.1.1w' }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v2
-    - run: rm Gemfile.lock
-    - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+
+    - name: Install OpenSSL
+      uses: ./.github/actions/install-openssl
       with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+        version: ${{ matrix.openssl }}
+
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ./.github/actions/install-ruby
+      with:
+        version: ${{ matrix.ruby-version }}
+        openssl-version: ${{ matrix.openssl }}
+
     - name: Run tests
       run: bundle exec rspec


### PR DESCRIPTION
## Motivation

Similar to https://github.com/cedarcode/tpm-key_attestation/pull/49.

> We got a notification that `ubuntu-20` images are being deprecated:
> 
> https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down
> 
> After upgrading to `ubuntu-24` a lot of tests started to break due to the Rubies on those images coming with OpenSSL version 3+. That means that, by upgrading, we wouldn't have any way of testing against OpenSSL 1.1.1w
> 
> We still want to test against OpenSSL `1.1.1w` despite it being EOL. 

## Summary

This PR updates our CI to manually install OpenSSL and Ruby so that we can test against different OpenSSL versions, without having to rely on the OpenSSL version that comes with ruby.

This also brings back the jobs ignored in c2c93d102ab4d842ec3d82e0e83a6e6c22cf166b as now we can specify the jobs to use `OpenSSL` `v1.1.1w`.